### PR TITLE
Token self-ownership

### DIFF
--- a/src/ERC6551CTGVault.sol
+++ b/src/ERC6551CTGVault.sol
@@ -10,40 +10,47 @@ import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
 import "erc6551/src/interfaces/IERC6551Registry.sol";
 import "erc6551/src/examples/simple/ERC6551Account.sol";
+import "erc6551/src/lib/ERC6551AccountLib.sol";
 
 contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
     using EnumerableMap for EnumerableMap.UintToAddressMap;
 
+    error EnableWithdrawalsFailed();
+    error WithdrawalFailed();
+
     // ERC6551 constants
-    address public constant registry =
-        0x000000006551c19487814612e58FE06813775758;
+    address public constant registry = 0x000000006551c19487814612e58FE06813775758;
     address public constant proxy = 0x55266d75D1a14E4572138116aF39863Ed6596E7F;
 
     // V3 account implementation
-    address public constant implementation =
-        0x41C8f39463A868d3A88af00cd0fe7102F30E44eC;
+    address public constant implementation = 0x41C8f39463A868d3A88af00cd0fe7102F30E44eC;
 
-    address public constant CTG_TOKEN_CONTRACT =
-        0x87f7266fA4e9da89E3710882bD0E10954fa1D48D;
+    address public constant CTG_TOKEN_CONTRACT = 0x87f7266fA4e9da89E3710882bD0E10954fa1D48D;
     uint256 public constant CTG_VOTING_START_TIMESTAMP = 1713398400;
     uint8 public constant STAKERS_SHARE_PERCENTAGE = 50;
 
     EnumerableMap.UintToAddressMap private tokenIdToOriginalOwnerMap;
 
+    address public selfOwnershipAccount;
     uint256 public amountPerStaker;
     bool public isWithdrawalEnabled;
 
-    function execute(
-        address to,
-        uint256 value,
-        bytes calldata data,
-        uint8 operation
-    ) external payable virtual override returns (bytes memory result) {
+    function execute(address to, uint256 value, bytes calldata data, uint8 operation)
+        external
+        payable
+        virtual
+        override
+        returns (bytes memory result)
+    {
         require(_isValidSigner(msg.sender), "Invalid signer");
         require(operation == 0, "Only call operations are supported");
 
         // Prevent Will from transferring CTG tokens out of the account
         require(to != CTG_TOKEN_CONTRACT, "Cannot call CTG token contract");
+
+        // Prevent Will from transferring his participant token out of the account
+        (, address accountTokenContract,) = token();
+        require(to != accountTokenContract, "Cannot call account token contract");
 
         // Prevent transfers of ETH out of the account
         require(value == 0, "Invalid value");
@@ -60,27 +67,37 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
         }
     }
 
-    function onERC721Received(
-        address,
-        address from,
-        uint256 tokenId,
-        bytes memory
-    ) public virtual override returns (bytes4) {
-        require(
-            IERC721(msg.sender).ownerOf(tokenId) == address(this),
-            "Invalid token owner"
-        );
+    function onERC721Received(address, address from, uint256 tokenId, bytes memory)
+        public
+        virtual
+        override
+        returns (bytes4)
+    {
+        require(IERC721(msg.sender).ownerOf(tokenId) == address(this), "Invalid token owner");
+
+        (uint256 chainId, address tokenContract, uint256 accountTokenId) = ERC6551AccountLib.token();
 
         // Record original owner of token sent in if CTG contract
-        if (msg.sender == CTG_TOKEN_CONTRACT) {
-            require(
-                block.timestamp < CTG_VOTING_START_TIMESTAMP,
-                "Deposits have been closed since voting started"
-            );
+        if (msg.sender == CTG_TOKEN_CONTRACT && accountTokenId != tokenId) {
+            require(block.timestamp < CTG_VOTING_START_TIMESTAMP, "Deposits have been closed since voting started");
             tokenIdToOriginalOwnerMap.set(tokenId, from);
         }
 
+        // Record sender of participant token (will's address)
+        if (chainId == block.chainid && msg.sender == tokenContract && tokenId == accountTokenId) {
+            selfOwnershipAccount = from;
+        }
+
         return this.onERC721Received.selector;
+    }
+
+    function owner() public view override returns (address) {
+        (uint256 chainId, address tokenContract, uint256 tokenId) = token();
+        if (chainId != block.chainid) return address(0);
+
+        if (selfOwnershipAccount != address(0)) return selfOwnershipAccount;
+
+        return IERC721(tokenContract).ownerOf(tokenId);
     }
 
     function enableWithdrawals() public {
@@ -92,14 +109,21 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
 
         // calculate amountPerStaker
         amountPerStaker =
-            ((address(this).balance * STAKERS_SHARE_PERCENTAGE) / 100) /
-            tokenIdToOriginalOwnerMap.length();
+            ((address(this).balance * STAKERS_SHARE_PERCENTAGE) / 100) / tokenIdToOriginalOwnerMap.length();
 
-        uint256 amountOfOwner = ((address(this).balance *
-            (100 - STAKERS_SHARE_PERCENTAGE)) / 100);
+        uint256 amountOfOwner = ((address(this).balance * (100 - STAKERS_SHARE_PERCENTAGE)) / 100);
+
+        // return participant token
+        if (selfOwnershipAccount != address(0)) {
+            address recipient = selfOwnershipAccount;
+            (, address accountTokenContract, uint256 tokenId) = token();
+            selfOwnershipAccount = address(0);
+            IERC721(accountTokenContract).safeTransferFrom(address(this), recipient, tokenId);
+        }
 
         // payout winner
-        address(owner()).call{value: amountOfOwner}("");
+        (bool success,) = owner().call{value: amountOfOwner}("");
+        if (!success) revert EnableWithdrawalsFailed();
     }
 
     function batchWithdraw() public {
@@ -129,19 +153,14 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
 
         EnumerableMap.remove(tokenIdToOriginalOwnerMap, tokenId);
 
-        IERC721(CTG_TOKEN_CONTRACT).transferFrom(
-            address(this),
-            originalOwner,
-            tokenId
-        );
+        IERC721(CTG_TOKEN_CONTRACT).transferFrom(address(this), originalOwner, tokenId);
 
         // Transfer a portion of the balance to the original owner
-        address(originalOwner).call{value: amountPerStaker}("");
+        (bool success,) = originalOwner.call{value: amountPerStaker}("");
+        if (!success) revert WithdrawalFailed();
     }
 
-    function getStakedTokenIds(
-        address staker
-    ) public view returns (uint256[] memory) {
+    function getStakedTokenIds(address staker) public view returns (uint256[] memory) {
         uint256 totalStakedTokens = tokenIdToOriginalOwnerMap.length();
         uint256[] memory stakedTokenIds = new uint256[](totalStakedTokens);
 

--- a/test/ERC6551CTGVaultTest.t.sol
+++ b/test/ERC6551CTGVaultTest.t.sol
@@ -15,8 +15,7 @@ contract ERC6551CTGVaultTest is Test {
 
     // Thank you Solady: https://github.com/Vectorized/solady/blob/9ea8a82b4485478b2ef5efdcc8012b10c2b7d865/src/accounts/LibERC6551.sol#L26
     /// @dev The canonical ERC6551 registry address for EVM chains.
-    address internal constant REGISTRY =
-        0x000000006551c19487814612e58FE06813775758;
+    address internal constant REGISTRY = 0x000000006551c19487814612e58FE06813775758;
 
     /// @dev The canonical ERC6551 registry bytecode for EVM chains.
     /// Useful for forge tests:
@@ -29,10 +28,7 @@ contract ERC6551CTGVaultTest is Test {
         ctgTokenContract = new DummyToken("CTG Token", "CTG");
         erc6551CTGVault = new ERC6551CTGVault();
 
-        vm.etch(
-            erc6551CTGVault.CTG_TOKEN_CONTRACT(),
-            address(ctgTokenContract).code
-        );
+        vm.etch(erc6551CTGVault.CTG_TOKEN_CONTRACT(), address(ctgTokenContract).code);
     }
 
     address will;
@@ -55,12 +51,14 @@ contract ERC6551CTGVaultTest is Test {
         tokenContract.mint(juryOwner2, 5); // Jury token #4
 
         willTba = IERC6551Registry(REGISTRY).createAccount(
-            address(erc6551CTGVault),
-            0,
-            block.chainid,
-            address(tokenContract),
-            1
+            address(erc6551CTGVault), 0, block.chainid, address(tokenContract), 1
         );
+
+        // move will's token to it's own account
+        vm.prank(will);
+        tokenContract.safeTransferFrom(will, willTba, 1);
+
+        assertEq(tokenContract.ownerOf(1), willTba);
 
         // Move jury tokens to will's vault account
         vm.prank(juryOwner1);
@@ -112,6 +110,7 @@ contract ERC6551CTGVaultTest is Test {
 
         vm.assertEq(juryOwner1.balance, 10 ether);
         vm.assertEq(juryOwner2.balance, 30 ether);
+        vm.assertEq(tokenContract.ownerOf(1), will);
         vm.assertEq(tokenContract.ownerOf(2), juryOwner1);
         vm.assertEq(tokenContract.ownerOf(3), juryOwner2);
         vm.assertEq(tokenContract.ownerOf(4), juryOwner2);
@@ -131,6 +130,7 @@ contract ERC6551CTGVaultTest is Test {
 
         vm.assertEq(juryOwner1.balance, 0 ether);
         vm.assertEq(juryOwner2.balance, 0 ether);
+        vm.assertEq(tokenContract.ownerOf(1), will);
         vm.assertEq(tokenContract.ownerOf(2), juryOwner1);
         vm.assertEq(tokenContract.ownerOf(3), juryOwner2);
         vm.assertEq(tokenContract.ownerOf(4), juryOwner2);
@@ -161,12 +161,7 @@ contract ERC6551CTGVaultTest is Test {
         ERC6551CTGVault(payable(willTba)).execute(
             address(tokenContract),
             0,
-            abi.encodeWithSignature(
-                "safeTransferFrom(address,address,uint256)",
-                juryOwner1,
-                willTba,
-                2
-            ),
+            abi.encodeWithSignature("safeTransferFrom(address,address,uint256)", juryOwner1, willTba, 2),
             0
         );
     }


### PR DESCRIPTION
Added support for transferring Will's CTG token into it's own account so that the TBA will receive the prize pot. Automatically sends back the NFT upon enable withdrawal and clears the cached ownership. Also prevents will from interacting with the CTG participant token contract using execute.