### PR TITLE
Enable withdrawals a month after voting starts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+auto_detect_remappings = false
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,8 +1,4 @@
-@openzeppelin/=lib/reference/lib/openzeppelin-contracts/
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
-ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/
-erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
-forge-std/=lib/forge-std/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
-reference/=lib/reference/
 erc6551/=lib/reference/
+
+forge-std/=lib/forge-std/src/

--- a/src/ERC6551CTGVault.sol
+++ b/src/ERC6551CTGVault.sol
@@ -25,15 +25,18 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
     // V3 account implementation
     address public constant implementation = 0x41C8f39463A868d3A88af00cd0fe7102F30E44eC;
 
+    // CTG contracts
     address public constant CTG_TOKEN_CONTRACT = 0x87f7266fA4e9da89E3710882bD0E10954fa1D48D;
     uint256 public constant CTG_VOTING_START_TIMESTAMP = 1713398400;
+    uint256 public constant WITHDRAWAL_ENABLED_TIMESTAMP = 1715918400; // 1 month after voting
+
     uint8 public constant STAKERS_SHARE_PERCENTAGE = 50;
 
     EnumerableMap.UintToAddressMap private tokenIdToOriginalOwnerMap;
 
     address public selfOwnershipAccount;
     uint256 public amountPerStaker;
-    bool public isWithdrawalEnabled;
+    bool public isEarlyWithdrawalEnabled;
 
     function execute(address to, uint256 value, bytes calldata data, uint8 operation)
         external
@@ -100,12 +103,16 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
         return IERC721(tokenContract).ownerOf(tokenId);
     }
 
-    function enableWithdrawals() public {
+    function isWithdrawalEnabled() public view returns (bool) {
+        return isEarlyWithdrawalEnabled || block.timestamp >= WITHDRAWAL_ENABLED_TIMESTAMP;
+    }
+
+    function enableEarlyWithdrawals() public {
         // onlyOwner
         require(_isValidSigner(msg.sender), "Invalid signer");
 
         // enable Withdrawals
-        isWithdrawalEnabled = true;
+        isEarlyWithdrawalEnabled = true;
 
         // calculate amountPerStaker
         amountPerStaker =
@@ -128,7 +135,7 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
 
     function batchWithdraw() public {
         // Check if withdrawals are enabled
-        require(isWithdrawalEnabled, "Withdrawals are not enabled");
+        require(isWithdrawalEnabled(), "Withdrawals are not enabled");
 
         uint256[] memory tokenIds = tokenIdToOriginalOwnerMap.keys();
         uint256 stakedTokenCount = tokenIds.length;
@@ -143,7 +150,7 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
 
     function withdraw(uint256 tokenId) public {
         // Check if withdrawals are enabled
-        require(isWithdrawalEnabled, "Withdrawals are not enabled");
+        require(isWithdrawalEnabled(), "Withdrawals are not enabled");
 
         _withdraw(tokenId);
     }

--- a/src/ERC6551CTGVault.sol
+++ b/src/ERC6551CTGVault.sol
@@ -180,8 +180,8 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
 
         uint256 count = 0;
         for (uint256 i = 0; i < totalStakedTokens; i++) {
-            (uint256 tokenId, address owner) = tokenIdToOriginalOwnerMap.at(i);
-            if (owner == staker) {
+            (uint256 tokenId, address originalOwner) = tokenIdToOriginalOwnerMap.at(i);
+            if (originalOwner == staker) {
                 stakedTokenIds[count] = tokenId;
                 count++;
             }

--- a/src/ERC6551CTGVault.sol
+++ b/src/ERC6551CTGVault.sol
@@ -18,15 +18,8 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
     error EnableWithdrawalsFailed();
     error WithdrawalFailed();
 
-    // ERC6551 constants
-    address public constant registry = 0x000000006551c19487814612e58FE06813775758;
-    address public constant proxy = 0x55266d75D1a14E4572138116aF39863Ed6596E7F;
-
-    // V3 account implementation
-    address public constant implementation = 0x41C8f39463A868d3A88af00cd0fe7102F30E44eC;
-
     // CTG contracts
-    address public constant CTG_TOKEN_CONTRACT = 0x87f7266fA4e9da89E3710882bD0E10954fa1D48D;
+    address public constant CTG_TOKEN_CONTRACT = 0x4DfC7EA5aC59B63223930C134796fecC4258d093;
     uint256 public constant CTG_VOTING_START_TIMESTAMP = 1713398400;
     uint256 public constant WITHDRAWAL_ENABLED_TIMESTAMP = 1715918400; // 1 month after voting
 
@@ -110,7 +103,7 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
     function enableEarlyWithdrawals() public {
         // onlyOwner
         require(_isValidSigner(msg.sender), "Invalid signer");
-
+        require(!isEarlyWithdrawalEnabled, "Early withdrawals already enabled");
         // enable Withdrawals
         isEarlyWithdrawalEnabled = true;
 

--- a/src/ERC6551CTGVault.sol
+++ b/src/ERC6551CTGVault.sol
@@ -115,8 +115,15 @@ contract ERC6551CTGVault is ERC721Holder, ERC6551Account {
         isEarlyWithdrawalEnabled = true;
 
         // calculate amountPerStaker
-        amountPerStaker =
-            ((address(this).balance * STAKERS_SHARE_PERCENTAGE) / 100) / tokenIdToOriginalOwnerMap.length();
+        uint256 numRemainingStakers = tokenIdToOriginalOwnerMap.length();
+
+        // Avoid division by zero if Will calls this function after all stakers have unstaked
+        if (numRemainingStakers == 0) {
+            amountPerStaker = 0;
+        } else {
+            amountPerStaker =
+                ((address(this).balance * STAKERS_SHARE_PERCENTAGE) / 100) / tokenIdToOriginalOwnerMap.length();
+        }
 
         uint256 amountOfOwner = ((address(this).balance * (100 - STAKERS_SHARE_PERCENTAGE)) / 100);
 

--- a/test/DummyToken.sol
+++ b/test/DummyToken.sol
@@ -1,10 +1,7 @@
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract DummyToken is ERC721 {
-    constructor(
-        string memory name,
-        string memory symbol
-    ) ERC721(name, symbol) {}
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
 
     function mint(address to, uint256 tokenId) public {
         _mint(to, tokenId);


### PR DESCRIPTION
This allows people to not need to trust that Will will call `enableWithdrawals()`.